### PR TITLE
Release 1.2.1

### DIFF
--- a/net.mkiol.SpeechNote.Addon.amd.metainfo.xml
+++ b/net.mkiol.SpeechNote.Addon.amd.metainfo.xml
@@ -20,7 +20,14 @@
   <url type="bugtracker">https://github.com/mkiol/dsnote/issues</url>
   <update_contact>dsnote_AT_mkiol.net</update_contact>
   <releases>
-    <release version="1.2.0" date="2024-08-01">
+    <release version="1.2.1" date="2024-08-15">
+      <description>
+        <ul>
+        <li>AVX2 and FMA are no longer required to run WhisperCpp when using GPU acceleration.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.2.0" date="2024-06-15">
       <description>
         <ul>
         <li>whisper.cpp update to version 1.6.2</li>

--- a/net.mkiol.SpeechNote.Addon.amd.yaml
+++ b/net.mkiol.SpeechNote.Addon.amd.yaml
@@ -359,6 +359,8 @@ modules:
       - -DWHISPER_BUILD_TESTS=OFF
       - -DWHISPER_BUILD_EXAMPLES=OFF
       - -DWHISPER_HIPBLAS=ON
+      - -DWHISPER_NO_AVX2=ON
+      - -DWHISPER_NO_FMA=ON
       - -DWHISPER_TARGET_NAME=whisper-hipblas
       - -DCMAKE_C_FLAGS='-O3'
       - -DCMAKE_CXX_FLAGS='-O3'


### PR DESCRIPTION
Changes:

- AVX2 and FMA are no longer required to run WhisperCpp when using GPU acceleration.